### PR TITLE
fix: stop using deprecated ts.factory.createClassDeclaration overload

### DIFF
--- a/.changeset/tidy-bikes-dance.md
+++ b/.changeset/tidy-bikes-dance.md
@@ -1,0 +1,5 @@
+---
+"webidl-dts-gen": patch
+---
+
+fix: stop using deprecated ts.factory.createClassDeclaration overload


### PR DESCRIPTION
- fix: stop using deprecated `ts.factory.createClassDeclaration` overload