### PR TITLE
Fix `implements` support for identifiers with underscores

### DIFF
--- a/.changeset/sharp-houses-compete.md
+++ b/.changeset/sharp-houses-compete.md
@@ -1,0 +1,5 @@
+---
+"webidl-dts-gen": patch
+---
+
+Fix 'implements' support for identifiers with underscores

--- a/packages/webidl-dts-gen/src/fixes.ts
+++ b/packages/webidl-dts-gen/src/fixes.ts
@@ -34,7 +34,7 @@ export const fixes = {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
 
-      const match = /([a-zA-Z0-9]+) implements ([a-zA-Z0-9]+);/gi.exec(line)
+      const match = /([a-zA-Z0-9_]+) implements ([a-zA-Z0-9_]+);/gi.exec(line)
 
       if (!match) {
         continue

--- a/packages/webidl-dts-gen/tst/index.spec.ts
+++ b/packages/webidl-dts-gen/tst/index.spec.ts
@@ -253,6 +253,29 @@ describe('convert', () => {
       await expectSourceToBeEqual(actual, expected)
     })
 
+    it('supports "implements" identifiers with underscores', async () => {
+      const idl = `
+        interface Foo_Bar {
+            void bar();
+        };
+        interface Baz_Bal {
+        };
+        Baz_Bal implements Foo_Bar;
+      `
+
+      const actual = await convert(idl, { emscripten: true })
+
+      const expected = withDefaultEmscriptenOutput(`
+        class Foo_Bar {
+            bar(): void;
+        }
+        class Baz_Bal extends Foo_Bar {
+        }
+      `)
+
+      await expectSourceToBeEqual(actual, expected)
+    })
+
     it('ignores commented out "implements" expressions', async () => {
       const idl = `
         interface Foo {


### PR DESCRIPTION
Was having a weird issue where implements wasn't being recognized in a WebIDL I have.

Dug around and found this issue where the regex doesn't account for identifiers that have underscores.

Let me know if you want me to file an Issue as well, or if just this PR will suffice.

Thanks for all your work on this library <3

Duplicate of https://github.com/pmndrs/webidl-dts-gen/pull/306 but with my non-main branch so I can more easily use my fork